### PR TITLE
Bump HaskellNet version to <0.6

### DIFF
--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -1,6 +1,6 @@
 name:                HaskellNet-SSL
 synopsis:            Helpers to connect to SSL/TLS mail servers with HaskellNet
-version:             0.3.1.0
+version:             0.3.2.0
 description:         This package ties together the HaskellNet and connection
                      packages to make it easy to open IMAP and SMTP connections
                      over SSL.
@@ -41,7 +41,7 @@ library
                        data-default
   else
     build-depends:     base >= 4 && < 5,
-                       HaskellNet >= 0.3 && < 0.5,
+                       HaskellNet >= 0.3 && < 0.6,
                        tls >= 1.2 && < 1.4,
                        connection == 0.2.*,
                        network >= 2.4 && < 2.7,


### PR DESCRIPTION
The current version conflicts (0.3.1.0) with the latest HaskellNet (0.5), although it compiles correctly with it.
(see fpco/stackage#960)