### PR TITLE
Derive Eq, Ord and Show instances for Settings data type

### DIFF
--- a/src/Network/HaskellNet/SSL.hs
+++ b/src/Network/HaskellNet/SSL.hs
@@ -10,7 +10,7 @@ data Settings = Settings
               , sslMaxLineLength               :: Int
               , sslLogToConsole                :: Bool
               , sslDisableCertificateValidation :: Bool
-              }
+              } deriving(Eq, Ord, Show)
 
 defaultSettingsWithPort :: PortNumber -> Settings
 defaultSettingsWithPort p = Settings


### PR DESCRIPTION
Those instances are the standard minimum, but I would also suggest adding others like `Data`, `Read` and `Generic`.