### PR TITLE
Bump dependency on 'network' package so it compiles with LTS-13

### DIFF
--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -1,6 +1,6 @@
 name:                HaskellNet-SSL
 synopsis:            Helpers to connect to SSL/TLS mail servers with HaskellNet
-version:             0.3.4.0
+version:             0.3.4.1
 description:         This package ties together the HaskellNet and connection
                      packages to make it easy to open IMAP and SMTP connections
                      over SSL.
@@ -44,6 +44,6 @@ library
                        HaskellNet >= 0.3 && < 0.6,
                        tls >= 1.2 && < 1.5,
                        connection >= 0.2.7 && < 0.3,
-                       network >= 2.4 && < 2.7,
+                       network >= 2.4 && < 2.9,
                        bytestring,
                        data-default


### PR DESCRIPTION
LTS-13 only contains network-2.8.0.0, so this change gets the package to compile again.