### PR TITLE
Allow newer versions of network library

### DIFF
--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -15,9 +15,13 @@ build-type:          Simple
 cabal-version:       >=1.8
 data-files:          README.md
 
-Flag NoUpperBounds
+flag NoUpperBounds
   Description: Removes upper bounds from all packages
   Default: False
+
+flag network-bsd
+   description: Get Network.BSD from the network-bsd package
+   default: True
 
 source-repository head
   type:     git
@@ -36,7 +40,6 @@ library
                        HaskellNet >= 0.3,
                        tls >= 1.2,
                        connection >= 0.2.7,
-                       network >= 2.4,
                        bytestring,
                        data-default
   else
@@ -44,6 +47,10 @@ library
                        HaskellNet >= 0.3 && < 0.6,
                        tls >= 1.2 && < 1.6,
                        connection >= 0.2.7 && < 0.4,
-                       network >= 2.4 && < 3.2,
                        bytestring,
                        data-default
+  if flag(network-bsd)
+    build-depends:     network >= 3.0,
+                       network-bsd >= 2.7
+  else
+    build-depends:     network >= 2.4 && < 3.0

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -1,6 +1,6 @@
 name:                HaskellNet-SSL
 synopsis:            Helpers to connect to SSL/TLS mail servers with HaskellNet
-version:             0.3.4.1
+version:             0.3.4.2
 description:         This package ties together the HaskellNet and connection
                      packages to make it easy to open IMAP and SMTP connections
                      over SSL.
@@ -44,6 +44,6 @@ library
                        HaskellNet >= 0.3 && < 0.6,
                        tls >= 1.2 && < 1.5,
                        connection >= 0.2.7 && < 0.3,
-                       network >= 2.4 && < 2.9,
+                       network >= 2.4 && < 3.2,
                        bytestring,
                        data-default

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -42,8 +42,8 @@ library
   else
     build-depends:     base >= 4 && < 5,
                        HaskellNet >= 0.3 && < 0.6,
-                       tls >= 1.2 && < 1.5,
-                       connection >= 0.2.7 && < 0.3,
+                       tls >= 1.2 && < 1.6,
+                       connection >= 0.2.7 && < 0.4,
                        network >= 2.4 && < 3.2,
                        bytestring,
                        data-default

--- a/src/Network/HaskellNet/SSL.hs
+++ b/src/Network/HaskellNet/SSL.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE CPP #-}
 module Network.HaskellNet.SSL
   ( Settings (..)
   , defaultSettingsWithPort
   ) where
 
+#if MIN_VERSION_network(3,0,0)
+import Network.Socket (PortNumber)
+#else
 import Network.Socket.Internal (PortNumber)
+#endif
 
 data Settings = Settings
               { sslPort                        :: PortNumber


### PR DESCRIPTION
[HaskellNet](https://github.com/jtdaugherty/HaskellNet) now allows newer versions of the network library, so we can too.

EDIT: Note that this enables HaskellNet-SSL to be used with GHC >= 8.8.