### PR TITLE
removed haskelnet upper version bound

### DIFF
--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -37,7 +37,7 @@ library
   other-modules:       Network.HaskellNet.SSL.Internal
   if flag(NoUpperBounds)
     build-depends:     base >= 4,
-                       HaskellNet >= 0.3,
+                       HaskellNet >= 0.3 && < 0.7,
                        tls >= 1.2,
                        connection >= 0.2.7,
                        bytestring,

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -37,14 +37,14 @@ library
   other-modules:       Network.HaskellNet.SSL.Internal
   if flag(NoUpperBounds)
     build-depends:     base >= 4,
-                       HaskellNet >= 0.3 && < 0.7,
+                       HaskellNet >= 0.3,
                        tls >= 1.2,
                        connection >= 0.2.7,
                        bytestring,
                        data-default
   else
     build-depends:     base >= 4 && < 5,
-                       HaskellNet >= 0.6,
+                       HaskellNet >= 0.6 && < 0.7,
                        tls >= 1.2 && < 1.6,
                        connection >= 0.2.7 && < 0.4,
                        bytestring,

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -44,7 +44,7 @@ library
                        data-default
   else
     build-depends:     base >= 4 && < 5,
-                       HaskellNet >= 0.6 && < 0.7,
+                       HaskellNet >= 0.3 && < 0.7,
                        tls >= 1.2 && < 1.6,
                        connection >= 0.2.7 && < 0.4,
                        bytestring,

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -44,7 +44,7 @@ library
                        data-default
   else
     build-depends:     base >= 4 && < 5,
-                       HaskellNet >= 0.3 && < 0.6,
+                       HaskellNet >= 0.6,
                        tls >= 1.2 && < 1.6,
                        connection >= 0.2.7 && < 0.4,
                        bytestring,


### PR DESCRIPTION
It looks like the current version works OK with HaskellNet-0.6 (the most recent version). 
This PR removes unnecessary version upper bound which allows to use it with newer HaskellNet.