### PR TITLE
use crypton-connection instead of the deprecated and insecure connection and update bytestring for ghc 9.8 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cabal.config
 *.aux
 *.hp
 .stack-work/
+dist-newstyle

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -34,7 +34,7 @@ library
   other-modules:       Network.HaskellNet.SSL.Internal
   build-depends:       base >= 4 && < 5,
                        HaskellNet >= 0.3 && < 0.7,
-                       connection >= 0.2.7 && < 0.4,
+                       crypton-connection >= 0.3.1,
                        bytestring >= 0.9 && < 0.12,
                        data-default >= 0.2 && < 0.8
   if flag(network-bsd)

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -35,7 +35,7 @@ library
   build-depends:       base >= 4 && < 5,
                        HaskellNet >= 0.3 && < 0.7,
                        crypton-connection >= 0.3.1,
-                       bytestring >= 0.9 && < 0.12,
+                       bytestring >= 0.9 && < 0.13,
                        data-default >= 0.2 && < 0.8
   if flag(network-bsd)
     build-depends:     network >= 3.0 && < 3.2,


### PR DESCRIPTION
`connection` is dead, long live `crypton-connection` 