### PR TITLE
bump network to 3.2.* and data-default to 0.8.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
 ## 0.4.0.1 -- 2025-01-17
 
 - Ignore 502 error on helo - fixes communication with some servers
+
+## 0.4.0.1 -- 2025-02-15
+
+- bump data-default and network

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -37,12 +37,12 @@ library
                        HaskellNet >= 0.3 && < 0.7,
                        crypton-connection >= 0.3.1 && < 0.5,
                        bytestring >= 0.9 && < 0.13,
-                       data-default >= 0.2 && < 0.8
+                       data-default >= 0.2 && < 0.9
   if flag(network-bsd)
-    build-depends:     network >= 3.0 && < 3.2,
+    build-depends:     network >= 3.0 && < 3.3,
                        network-bsd >= 2.7 && < 2.9
   else
-    build-depends:     network >= 2.4 && < 3.0
+    build-depends:     network >= 2.4 && < 3.3
 
 executable HaskellNet-SSL-example
   hs-source-dirs:   examples

--- a/HaskellNet-SSL.cabal
+++ b/HaskellNet-SSL.cabal
@@ -1,6 +1,6 @@
 name:                HaskellNet-SSL
 synopsis:            Helpers to connect to SSL/TLS mail servers with HaskellNet
-version:             0.4.0.1
+version:             0.4.0.2
 description:         This package ties together the HaskellNet and connection
                      packages to make it easy to open IMAP and SMTP connections
                      over SSL.

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,6 @@
 packages: .
 
 allow-newer:
-  HaskellNet:base
+  , HaskellNet:base
+  , HaskellNet:network
+  , HaskellNet:data-default


### PR DESCRIPTION
This is a partner PR for the same [HaskellNet PR](https://github.com/qnikst/HaskellNet/pull/103) . There is a network 3.2.7  and data-default 0.8 published on hackage, they both compile cleanly on this repository. The module structure did not change enough to make this project not compile. I am bumping the version on both of them. 

Supersedes #40 